### PR TITLE
Add API tender partial for Sezzle Payments

### DIFF
--- a/app/views/workarea/api/storefront/orders/tenders/_sezzle.json.jbuilder
+++ b/app/views/workarea/api/storefront/orders/tenders/_sezzle.json.jbuilder
@@ -1,0 +1,4 @@
+json.type 'sezzle'
+json.amount tender.amount
+json.sezzle_id tender.sezzle_id
+json.sezzle_payment_intent tender.intent


### PR DESCRIPTION
Adds a new parital to display sezzle payments when an GET is made
against a placed order in the Workarea API.