### PR TITLE
SEZZ-5  Add multi-language support

### DIFF
--- a/app/helpers/workarea/storefront/sezzle_helper.rb
+++ b/app/helpers/workarea/storefront/sezzle_helper.rb
@@ -1,0 +1,9 @@
+module Workarea
+  module Storefront
+    module SezzleHelper
+      def sezzle_language
+        I18n.locale == :fr ? 'fr' : 'en'
+      end
+    end
+  end
+end

--- a/app/views/workarea/storefront/sezzle/_script.html.haml
+++ b/app/views/workarea/storefront/sezzle/_script.html.haml
@@ -11,12 +11,9 @@
         {
           targetXPath: "#{Workarea.config.sezzle.cart_config[:target_xpath]}",
           renderToPath: "#{Workarea.config.sezzle.cart_config[:render_to_path]}",
-          urlMatch: "#{Workarea.config.sezzle.cart_config[:url_match]}",
-          altVersionTemplate: {
-            'en': '4 interest-free payments of %%price%% with %%logo%% %%info%%',
-            'fr': '4 paiements de %%price%% sans intérêts avec %%logo%% %%info%%'
-          }
+          urlMatch: "#{Workarea.config.sezzle.cart_config[:url_match]}"
         }
-      ]
+      ],
+      language: "#{sezzle_language}"
     }
   %script{ src: "https://widget.sezzle.com/v1/javascript/price-widget?uuid=#{Workarea.config.sezzle_merchant_id}" }

--- a/lib/workarea/sezzle/engine.rb
+++ b/lib/workarea/sezzle/engine.rb
@@ -5,6 +5,12 @@ module Workarea
     class Engine < ::Rails::Engine
       include Workarea::Plugin
       isolate_namespace Workarea::Sezzle
+
+      config.to_prepare do
+        Workarea::Storefront::ApplicationController.helper(
+          Workarea::Storefront::SezzleHelper
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Only supports EN and FR, per Sezzle docs.
Add new helper for getting Rails locale.
Remove translation templates as they were the defaults anyway.
Add language to script.